### PR TITLE
More tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,11 +182,19 @@ bin/goss:
 	curl -o bin/goss -L https://github.com/aelsabbahy/goss/releases/download/v${GOSS_VERSION}/goss-linux-amd64
 	chmod +x bin/goss
 
-test: bin/goss
-	@docker-compose -f tests_solr/docker-compose.yml down || true
-	@docker-compose -f tests_solr/docker-compose.yml up -d
-	@docker-compose -f tests_solr/docker-compose.yml exec -T goss \
-		goss -g solr.yaml validate --retry-timeout 30s --sleep 1s --max-concurrent 4 --format documentation
-	@docker-compose -f tests_solr/docker-compose.yml down || true
+test3.5: bin/goss
+	make -C tests_solr tests SOLR_VERSION=3.5
 
-tests: test
+test4.9: bin/goss
+	make -C tests_solr tests SOLR_VERSION=4.9
+
+test6.4: bin/goss
+	make -C tests_solr tests SOLR_VERSION=6.4
+
+test6.6: bin/goss
+	make -C tests_solr tests SOLR_VERSION=6.6
+
+test7.5: bin/goss
+	make -C tests_solr tests SOLR_VERSION=7.5
+
+tests: | test3.5 test4.9 test6.4 test6.6 test7.5

--- a/tests_solr/Makefile
+++ b/tests_solr/Makefile
@@ -1,0 +1,9 @@
+SOLR_VERSION := ""
+
+tests:
+	@echo "Testing solr $(SOLR_VERSION) =========="
+	@docker-compose down || true
+	@SOLR_VERSION=$(SOLR_VERSION) docker-compose up -d solr
+	sleep 2
+	@docker-compose up --abort-on-container-exit --exit-code-from client client
+	@docker-compose down || true

--- a/tests_solr/docker-compose.yml
+++ b/tests_solr/docker-compose.yml
@@ -3,13 +3,18 @@
 version: '3'
 services:
     solr:
-        image: bearstech/solr:latest
+        image: bearstech/solr:${SOLR_VERSION}
         ports:
             - '8983:8983'
 
-    goss:
+    client:
         image: bearstech/debian:stretch
-        command: "sleep 600000000000000000000000"
+        command: >
+            goss -g solr.yaml validate
+                --retry-timeout 30s
+                --sleep 1s
+                --max-concurrent 4
+                --format documentation
         volumes:
             - ../bin/goss:/usr/bin/goss
             - ../tests_solr:/goss


### PR DESCRIPTION
Tests are broken for version 3.5 and 4.9.

Goss can use vars file, for handling specific url pattern for specific version.