### PR TITLE
openjdk in one layer

### DIFF
--- a/Dockerfile.35
+++ b/Dockerfile.35
@@ -3,19 +3,21 @@ FROM bearstech/debian:stretch
 
 ENV DEBIAN_FRONTEND noninteractive
 
-ENV SOLR_VERSION=3.5.0
-ENV JETTY_VERSION=8.1.10
-
-ENV BUILD_DIR_SORL=build/$SOLR_VERSION/solr
-ENV BUILD_DIR_JETTY=build/jetty-$JETTY_VERSION/jetty
-
 # we need openjdk
 RUN set -eux \
     &&  apt-get update \
     &&  apt-get install -y --no-install-recommends \
                     openjdk-8-jre-headless \
     &&  apt-get clean \
-    &&  rm -rf /var/lib/apt/lists/* \
+    &&  rm -rf /var/lib/apt/lists/*
+
+ENV SOLR_VERSION=3.5.0
+ENV JETTY_VERSION=8.1.10
+
+ENV BUILD_DIR_SORL=build/$SOLR_VERSION/solr
+ENV BUILD_DIR_JETTY=build/jetty-$JETTY_VERSION/jetty
+
+RUN set -eux \
     # solr installation dir
     &&  mkdir -p /opt/solr/solr/ \
     # config dir /etc/solr/conf

--- a/Dockerfile.49
+++ b/Dockerfile.49
@@ -3,17 +3,20 @@ FROM bearstech/debian:stretch
 
 ENV DEBIAN_FRONTEND noninteractive
 
-ENV SOLR_VERSION=4.9.1
-
-ENV BUILD_DIR=build/$SOLR_VERSION/solr
-
 # we need openjdk
 RUN set -eux \
     &&  apt-get update \
     &&  apt-get install -y --no-install-recommends \
                     openjdk-8-jre-headless \
     &&  apt-get clean \
-    &&  rm -rf /var/lib/apt/lists/* \
+    &&  rm -rf /var/lib/apt/lists/*
+
+ENV SOLR_VERSION=4.9.1
+
+ENV BUILD_DIR=build/$SOLR_VERSION/solr
+
+# we need openjdk
+RUN set -eux \
     # solr installation dir
     &&  mkdir -p /opt/solr/solr/collection1/ \
     # config dir /etc/solr/conf

--- a/Dockerfile.64
+++ b/Dockerfile.64
@@ -3,17 +3,20 @@ FROM bearstech/debian:stretch
 
 ENV DEBIAN_FRONTEND noninteractive
 
-ENV SOLR_VERSION=6.4.2
-
-ENV BUILD_DIR=build/$SOLR_VERSION/solr
-
 # we need openjdk
 RUN set -eux \
     &&  apt-get update \
     &&  apt-get install -y --no-install-recommends \
                     openjdk-8-jre-headless \
     &&  apt-get clean \
-    &&  rm -rf /var/lib/apt/lists/* \
+    &&  rm -rf /var/lib/apt/lists/*
+
+ENV SOLR_VERSION=6.4.2
+
+ENV BUILD_DIR=build/$SOLR_VERSION/solr
+
+# we need openjdk
+RUN set -eux \
     # solr installation dir
     &&  mkdir -p /opt/solr \
     # config dir /etc/solr/conf

--- a/Dockerfile.66
+++ b/Dockerfile.66
@@ -3,17 +3,20 @@ FROM bearstech/debian:stretch
 
 ENV DEBIAN_FRONTEND noninteractive
 
-ENV SOLR_VERSION=6.6.5
-
-ENV BUILD_DIR=build/$SOLR_VERSION/solr
-
 # we need openjdk
 RUN set -eux \
     &&  apt-get update \
     &&  apt-get install -y --no-install-recommends \
                     openjdk-8-jre-headless \
     &&  apt-get clean \
-    &&  rm -rf /var/lib/apt/lists/* \
+    &&  rm -rf /var/lib/apt/lists/*
+
+ENV SOLR_VERSION=6.6.5
+
+ENV BUILD_DIR=build/$SOLR_VERSION/solr
+
+# we need openjdk
+RUN set -eux \
     # solr installation dir
     &&  mkdir -p /opt/solr \
     # config dir /etc/solr/conf

--- a/Dockerfile.75
+++ b/Dockerfile.75
@@ -3,17 +3,20 @@ FROM bearstech/debian:stretch
 
 ENV DEBIAN_FRONTEND noninteractive
 
-ENV SOLR_VERSION=7.5.0
-
-ENV BUILD_DIR=build/$SOLR_VERSION/solr
-
 # we need openjdk
 RUN set -eux \
     &&  apt-get update \
     &&  apt-get install -y --no-install-recommends \
                     openjdk-8-jre-headless \
     &&  apt-get clean \
-    &&  rm -rf /var/lib/apt/lists/* \
+    &&  rm -rf /var/lib/apt/lists/*
+
+ENV SOLR_VERSION=7.5.0
+
+ENV BUILD_DIR=build/$SOLR_VERSION/solr
+
+# we need openjdk
+RUN set -eux \
     # solr installation dir
     &&  mkdir -p /opt/solr \
     # config dir /etc/solr/conf


### PR DESCRIPTION
Docker will cache the openjdk install. It's quicker and lighter.